### PR TITLE
[Compatibility Fix] Update sandbox example

### DIFF
--- a/SandBox/MakefileCppUTest.mk
+++ b/SandBox/MakefileCppUTest.mk
@@ -28,5 +28,15 @@ INCLUDE_DIRS =\
 #CPPUTEST_WARNINGFLAGS += -pedantic-errors -Wconversion -Wshadow  -Wextra
 CPPUTEST_WARNINGFLAGS += -Wall -Werror -Wswitch-default -Wswitch-enum 
 
+# Temporary setting of C++ flag to ignore C++14 compatability for gcc > 5
+# Should be moved into CPPUTest make file with PR
+CPPUTEST_CXX_WARNINGFLAGS = -Wno-c++14-compat
+
+# Temporary setting in Sandbox, CppuTest makefile should also detect clang > 7
+# and set flags.
+ifeq ($(CPP_PLATFORM),clang)
+	CPPUTEST_CXX_WARNINGFLAGS += -Wno-reserved-id-macro -Wno-keyword-macro
+	CPPUTEST_C_WARNINGFLAGS += -Wno-reserved-id-macro -Wno-keyword-macro
+endif
 
 include $(CPPUTEST_HOME)/build/MakefileWorker.mk

--- a/SandBox/MakefileCppUTest.mk
+++ b/SandBox/MakefileCppUTest.mk
@@ -27,6 +27,7 @@ INCLUDE_DIRS =\
   
 #CPPUTEST_WARNINGFLAGS += -pedantic-errors -Wconversion -Wshadow  -Wextra
 CPPUTEST_WARNINGFLAGS += -Wall -Werror -Wswitch-default -Wswitch-enum 
-
+CPPUTEST_WARNINGFLAGS += -Wno-reserved-id-macro
+CPPUTEST_WARNINGFLAGS += -Wno-keyword-macro
 
 include $(CPPUTEST_HOME)/build/MakefileWorker.mk

--- a/SandBox/MakefileCppUTest.mk
+++ b/SandBox/MakefileCppUTest.mk
@@ -27,7 +27,16 @@ INCLUDE_DIRS =\
   
 #CPPUTEST_WARNINGFLAGS += -pedantic-errors -Wconversion -Wshadow  -Wextra
 CPPUTEST_WARNINGFLAGS += -Wall -Werror -Wswitch-default -Wswitch-enum 
-CPPUTEST_WARNINGFLAGS += -Wno-reserved-id-macro
-CPPUTEST_WARNINGFLAGS += -Wno-keyword-macro
+
+# Temporary setting of C++ flag to ignore C++14 compatability for gcc > 5
+# Should be moved into CPPUTest make file with PR
+CPPUTEST_CXX_WARNINGFLAGS = -Wno-c++14-compat
+
+# Temporary setting in Sandbox, CppuTest makefile should also detect clang > 7
+# and set flags.
+ifeq ($(CPP_PLATFORM),clang)
+	CPPUTEST_CXX_WARNINGFLAGS += -Wno-reserved-id-macro -Wno-keyword-macro
+	CPPUTEST_C_WARNINGFLAGS += -Wno-reserved-id-macro -Wno-keyword-macro
+endif
 
 include $(CPPUTEST_HOME)/build/MakefileWorker.mk

--- a/code-t0/Makefile
+++ b/code-t0/Makefile
@@ -23,6 +23,14 @@ CPPUTEST_CFLAGS += -Wextra
 CPPUTEST_CFLAGS += -pedantic 
 CPPUTEST_CFLAGS += -Wstrict-prototypes
 
+# Temporary setting of C++ flag to ignore C++14 compatability for gcc > 5
+# Should be moved into CPPUTest make file with PR
+CPPUTEST_CXX_WARNINGFLAGS = -Wno-c++14-compat
+# Flags to ignore keywords with OS X (clang and gcc wrapper)
+# Should be moved into CPPUTest make file with PR
+CPPUTEST_CXX_WARNINGFLAGS += -Wno-reserved-id-macro -Wno-keyword-macro
+CPPUTEST_C_WARNINGFLAGS += -Wno-reserved-id-macro -Wno-keyword-macro
+
 SRC_DIRS = \
 	src/util\
 	src/HomeAutomation\

--- a/code-t0/Makefile
+++ b/code-t0/Makefile
@@ -17,7 +17,21 @@ CPP_PLATFORM = Gcc
 CPPUTEST_WARNINGFLAGS += -Wall 
 CPPUTEST_WARNINGFLAGS += -Werror 
 CPPUTEST_WARNINGFLAGS += -Wswitch-default 
-CPPUTEST_WARNINGFLAGS += -Wswitch-enum  
+CPPUTEST_WARNINGFLAGS += -Wswitch-enum
+CPPUTEST_WARNINGFLAGS += -Wstrict-prototypes
+
+# Temporary setting of C++ flag to ignore C++14 compatability for gcc > 5
+# Should be moved into CPPUTest make file with PR
+CPPUTEST_CXX_WARNINGFLAGS = -Wno-c++14-compat
+
+ifeq ($(CPP_PLATFORM),clang)
+	CPPUTEST_WARNINGFLAGS += -Wno-documentation
+	CPPUTEST_WARNINGFLAGS += -Wno-long-long
+	CPPUTEST_WARNINGFLAGS += -Wno-sign-conversion
+	CPPUTEST_WARNINGFLAGS += -Wno-covered-switch-default
+	CPPUTEST_WARNINGFLAGS += -Wno-shorten-64-to-32
+endif
+
 CPPUTEST_CFLAGS += -std=c89
 CPPUTEST_CFLAGS += -Wextra 
 CPPUTEST_CFLAGS += -pedantic 

--- a/code-t0/Makefile
+++ b/code-t0/Makefile
@@ -19,6 +19,7 @@ CPPUTEST_WARNINGFLAGS += -Werror
 CPPUTEST_WARNINGFLAGS += -Wswitch-default 
 CPPUTEST_WARNINGFLAGS += -Wswitch-enum
 CPPUTEST_WARNINGFLAGS += -Wno-documentation
+CPPUTEST_WARNINGFLAGS += -Wno-unknown-warning-option
 CPPUTEST_CFLAGS += -Wextra 
 CPPUTEST_CFLAGS += -pedantic 
 CPPUTEST_CFLAGS += -Wstrict-prototypes

--- a/code-t1/Makefile
+++ b/code-t1/Makefile
@@ -19,6 +19,17 @@ CPPUTEST_WARNINGFLAGS += -Werror
 CPPUTEST_WARNINGFLAGS += -Wswitch-default 
 CPPUTEST_WARNINGFLAGS += -Wswitch-enum  
 CPPUTEST_WARNINGFLAGS += -Wno-unused-parameter
+CPPUTEST_CXX_WARNINGFLAGS = -Wno-c++14-compat
+
+ifeq ($(CPP_PLATFORM),clang)
+	CPPUTEST_WARNINGFLAGS += -Wno-documentation
+	CPPUTEST_WARNINGFLAGS += -Wno-long-long
+	CPPUTEST_WARNINGFLAGS += -Wno-sign-conversion
+	CPPUTEST_WARNINGFLAGS += -Wno-covered-switch-default
+	CPPUTEST_WARNINGFLAGS += -Wno-shorten-64-to-32
+	CPPUTEST_WARNINGFLAGS += -Wno-shadow
+endif
+
 CPPUTEST_CFLAGS += -std=c89
 CPPUTEST_CFLAGS += -Wextra 
 CPPUTEST_CFLAGS += -pedantic 

--- a/code-t1/Makefile
+++ b/code-t1/Makefile
@@ -21,6 +21,7 @@ CPPUTEST_WARNINGFLAGS += -Wswitch-enum
 CPPUTEST_WARNINGFLAGS += -Wno-unused-parameter
 CPPUTEST_WARNINGFLAGS += -Wno-shadow
 CPPUTEST_WARNINGFLAGS += -Wno-covered-switch-default
+CPPUTEST_WARNINGFLAGS += -Wno-unknown-warning-option
 CPPUTEST_CFLAGS += -std=c99
 CPPUTEST_CFLAGS += -Wextra 
 CPPUTEST_CFLAGS += -pedantic 

--- a/code-t1/Makefile
+++ b/code-t1/Makefile
@@ -26,6 +26,14 @@ CPPUTEST_CFLAGS += -Wextra
 CPPUTEST_CFLAGS += -pedantic 
 CPPUTEST_CFLAGS += -Wstrict-prototypes
 
+# Temporary setting of C++ flag to ignore C++14 compatability for gcc > 5
+# Should be moved into CPPUTest make file with PR
+CPPUTEST_CXX_WARNINGFLAGS = -Wno-c++14-compat
+# Flags to ignore keywords with OS X (clang and gcc wrapper)
+# Should be moved into CPPUTest make file with PR
+CPPUTEST_CXX_WARNINGFLAGS += -Wno-reserved-id-macro -Wno-keyword-macro
+CPPUTEST_C_WARNINGFLAGS += -Wno-reserved-id-macro -Wno-keyword-macro
+
 SRC_DIRS = \
 	src/*\
 	src/MyOS/Acme\

--- a/code-t1/tests/IO/FlashTest.cpp
+++ b/code-t1/tests/IO/FlashTest.cpp
@@ -90,7 +90,7 @@ TEST_GROUP(Flash)
 
     void simulateDeviceStatusWithRepeat(ioData status, int repeatCount)
     {
-        mock().expectNCalls(repeatCount, "IO_Read")
+        mock().expectNCalls((unsigned int) repeatCount, "IO_Read")
                 .withParameter("addr", StatusRegister)
                 .andReturnValue((int) status);
     }

--- a/code-t2/Makefile
+++ b/code-t2/Makefile
@@ -18,6 +18,20 @@ CPPUTEST_WARNINGFLAGS += -Werror
 CPPUTEST_WARNINGFLAGS += -Wswitch-default 
 CPPUTEST_WARNINGFLAGS += -Wswitch-enum  
 CPPUTEST_WARNINGFLAGS += -Wno-unused-parameter
+
+# Temporary setting of C++ flag to ignore C++14 compatability for gcc > 5
+# Should be moved into CPPUTest make file with PR
+CPPUTEST_CXX_WARNINGFLAGS = -Wno-c++14-compat
+
+ifeq ($(CPP_PLATFORM),clang)
+	CPPUTEST_WARNINGFLAGS += -Wno-documentation
+	CPPUTEST_WARNINGFLAGS += -Wno-long-long
+	CPPUTEST_WARNINGFLAGS += -Wno-sign-conversion
+	CPPUTEST_WARNINGFLAGS += -Wno-covered-switch-default
+	CPPUTEST_WARNINGFLAGS += -Wno-shorten-64-to-32
+endif
+
+
 CPPUTEST_CFLAGS += -std=c89
 CPPUTEST_CFLAGS += -Wextra 
 CPPUTEST_CFLAGS += -pedantic 

--- a/code-t2/Makefile
+++ b/code-t2/Makefile
@@ -18,6 +18,7 @@ CPPUTEST_WARNINGFLAGS += -Werror
 CPPUTEST_WARNINGFLAGS += -Wswitch-default 
 CPPUTEST_WARNINGFLAGS += -Wswitch-enum  
 CPPUTEST_WARNINGFLAGS += -Wno-unused-parameter
+CPPUTEST_WARNINGFLAGS += -Wno-unknown-warning-option
 CPPUTEST_CFLAGS += -std=c99
 CPPUTEST_CFLAGS += -Wextra 
 CPPUTEST_CFLAGS += -pedantic 

--- a/code-t2/Makefile
+++ b/code-t2/Makefile
@@ -23,6 +23,14 @@ CPPUTEST_CFLAGS += -Wextra
 CPPUTEST_CFLAGS += -pedantic 
 CPPUTEST_CFLAGS += -Wstrict-prototypes
 
+# Temporary setting of C++ flag to ignore C++14 compatability for gcc > 5
+# Should be moved into CPPUTest make file with PR
+CPPUTEST_CXX_WARNINGFLAGS = -Wno-c++14-compat
+# Flags to ignore keywords with OS X (clang and gcc wrapper)
+# Should be moved into CPPUTest make file with PR
+CPPUTEST_CXX_WARNINGFLAGS += -Wno-reserved-id-macro -Wno-keyword-macro
+CPPUTEST_C_WARNINGFLAGS += -Wno-reserved-id-macro -Wno-keyword-macro
+
 SRC_DIRS = \
 	src/*\
 

--- a/code-t3/Makefile
+++ b/code-t3/Makefile
@@ -19,6 +19,7 @@ CPPUTEST_WARNINGFLAGS += -Werror
 CPPUTEST_WARNINGFLAGS += -Wswitch-default 
 CPPUTEST_WARNINGFLAGS += -Wswitch-enum  
 CPPUTEST_WARNINGFLAGS += -Wno-unused-parameter
+CPPUTEST_WARNINGFLAGS += -Wno-unknown-warning-option
 CPPUTEST_CFLAGS += -std=c99
 CPPUTEST_CFLAGS += -Wextra 
 CPPUTEST_CFLAGS += -pedantic 

--- a/code-t3/Makefile
+++ b/code-t3/Makefile
@@ -24,6 +24,14 @@ CPPUTEST_CFLAGS += -Wextra
 CPPUTEST_CFLAGS += -pedantic 
 CPPUTEST_CFLAGS += -Wstrict-prototypes
 
+# Temporary setting of C++ flag to ignore C++14 compatability for gcc > 5
+# Should be moved into CPPUTest make file with PR
+CPPUTEST_CXX_WARNINGFLAGS = -Wno-c++14-compat
+# Flags to ignore keywords with OS X (clang and gcc wrapper)
+# Should be moved into CPPUTest make file with PR
+CPPUTEST_CXX_WARNINGFLAGS += -Wno-reserved-id-macro -Wno-keyword-macro
+CPPUTEST_C_WARNINGFLAGS += -Wno-reserved-id-macro -Wno-keyword-macro
+
 SRC_DIRS = \
 	src/*\
 

--- a/code-t3/Makefile
+++ b/code-t3/Makefile
@@ -19,6 +19,19 @@ CPPUTEST_WARNINGFLAGS += -Werror
 CPPUTEST_WARNINGFLAGS += -Wswitch-default 
 CPPUTEST_WARNINGFLAGS += -Wswitch-enum  
 CPPUTEST_WARNINGFLAGS += -Wno-unused-parameter
+
+# Temporary setting of C++ flag to ignore C++14 compatability for gcc > 5
+# Should be moved into CPPUTest make file with PR
+CPPUTEST_CXX_WARNINGFLAGS = -Wno-c++14-compat
+
+ifeq ($(CPP_PLATFORM),clang)
+	CPPUTEST_WARNINGFLAGS += -Wno-documentation
+	CPPUTEST_WARNINGFLAGS += -Wno-long-long
+	CPPUTEST_WARNINGFLAGS += -Wno-sign-conversion
+	CPPUTEST_WARNINGFLAGS += -Wno-covered-switch-default
+	CPPUTEST_WARNINGFLAGS += -Wno-shorten-64-to-32
+endif
+
 CPPUTEST_CFLAGS += -std=c89
 CPPUTEST_CFLAGS += -Wextra 
 CPPUTEST_CFLAGS += -pedantic 

--- a/code/MakefileCppUTest.mk
+++ b/code/MakefileCppUTest.mk
@@ -54,6 +54,7 @@ MOCKS_SRC_DIRS = \
 CPPUTEST_WARNINGFLAGS = -Wall -Wswitch-default -Werror 
 CPPUTEST_WARNINGFLAGS += -Wno-missing-prototypes -Wno-format-nonliteral -Wno-sign-conversion -Wno-pedantic 
 CPPUTEST_WARNINGFLAGS += -Wno-shadow -Wno-missing-field-initializers -Wno-unused-parameter
+CPPUTEST_WARNINGFLAGS += -Wno-unknown-warning-option
 #CPPUTEST_CFLAGS = -std=c89 
 CPPUTEST_CFLAGS += -Wall -Wstrict-prototypes -pedantic
 LD_LIBRARIES = -lpthread

--- a/code/MakefileCppUTest.mk
+++ b/code/MakefileCppUTest.mk
@@ -58,6 +58,13 @@ CPPUTEST_WARNINGFLAGS += -Wno-shadow -Wno-missing-field-initializers -Wno-unused
 CPPUTEST_CFLAGS += -Wall -Wstrict-prototypes -pedantic
 LD_LIBRARIES = -lpthread
 	
-  
+# Temporary setting of C++ flag to ignore C++14 compatability for gcc > 5
+# Should be moved into CPPUTest make file with PR
+CPPUTEST_CXX_WARNINGFLAGS = -Wno-c++14-compat
+# Flags to ignore keywords with OS X (clang and gcc wrapper)
+# Should be moved into CPPUTest make file with PR
+CPPUTEST_CXX_WARNINGFLAGS += -Wno-reserved-id-macro -Wno-keyword-macro
+CPPUTEST_C_WARNINGFLAGS += -Wno-reserved-id-macro -Wno-keyword-macro
+
 include $(CPPUTEST_HOME)/build/MakefileWorker.mk
 

--- a/code/tests/HomeAutomation/FakeTimeService.c
+++ b/code/tests/HomeAutomation/FakeTimeService.c
@@ -45,8 +45,9 @@ void TimeService_Destroy(void)
 
 void FakeTimeService_MinuteIsUp(void)
 {
-    if (callback != NULL);
+    if (callback != NULL) {
         callback();
+    }
 }
 
 void TimeService_SetPeriodicAlarmInSeconds(int seconds, WakeupCallback cb)

--- a/code/unity/HomeAutomation/FakeTimeService.c
+++ b/code/unity/HomeAutomation/FakeTimeService.c
@@ -45,8 +45,9 @@ void TimeService_Destroy(void)
 
 void FakeTimeService_MinuteIsUp(void)
 {
-    if (callback != NULL);
+    if (callback != NULL) {
         callback();
+    }
 }
 
 void TimeService_SetPeriodicAlarmInSeconds(int seconds, WakeupCallback cb)


### PR DESCRIPTION
This change will allow the sandbox example to compile with gcc 5.40 and CppUTest 3.8