### PR TITLE
Cleaned up build by ignoring warnings and fixing empty if()'s.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@
 #	CppUTest built with extensions
 #	CPPUTEST_HOME defined
 	
+export CPPUTEST_WARNINGFLAGS += -Wno-reserved-id-macro -Wno-keyword-macro
+
 all: 
 	make -i -C code
 	make -i -C code-t0

--- a/code/tests/HomeAutomation/FakeTimeService.c
+++ b/code/tests/HomeAutomation/FakeTimeService.c
@@ -45,8 +45,9 @@ void TimeService_Destroy(void)
 
 void FakeTimeService_MinuteIsUp(void)
 {
-    if (callback != NULL);
+    if (callback != NULL) {
         callback();
+    }
 }
 
 void TimeService_SetPeriodicAlarmInSeconds(int seconds, WakeupCallback cb)

--- a/code/unity/HomeAutomation/FakeTimeService.c
+++ b/code/unity/HomeAutomation/FakeTimeService.c
@@ -45,8 +45,9 @@ void TimeService_Destroy(void)
 
 void FakeTimeService_MinuteIsUp(void)
 {
-    if (callback != NULL);
+    if (callback != NULL) {
         callback();
+    }
 }
 
 void TimeService_SetPeriodicAlarmInSeconds(int seconds, WakeupCallback cb)


### PR DESCRIPTION
The two warnings added were: -Wno-reserved-id-macro -Wno-keyword-macro

The TDD framework code legitimately triggers those warnings.

Only tested on a Macbook with Sierra 10.12.5.